### PR TITLE
bundle react and tailwind locally

### DIFF
--- a/mutation-brawler/README.md
+++ b/mutation-brawler/README.md
@@ -18,3 +18,13 @@ View your app in AI Studio: https://ai.studio/apps/drive/1P6ME9t0XOASi_B-PHsu5q3
 2. Set the `GEMINI_API_KEY` in [.env.local](.env.local) to your Gemini API key
 3. Run the app:
    `npm run dev`
+
+## Updating dependencies
+
+React, React DOM, Tailwind CSS and the build tooling are pinned to exact versions
+in `package.json` to ensure reproducible builds. When upgrades are needed:
+
+1. Update the version numbers in `package.json`.
+2. Run `npm install` to apply the changes.
+3. Run `npm run build` to verify the app still compiles.
+4. Commit the updated files once tests pass.

--- a/mutation-brawler/index.css
+++ b/mutation-brawler/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/mutation-brawler/index.html
+++ b/mutation-brawler/index.html
@@ -4,16 +4,6 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Mutation Brawler</title>
-    <script src="https://cdn.tailwindcss.com"></script>
-    <script type="importmap">
-      {
-        "imports": {
-          "react-dom/": "https://esm.sh/react-dom@^19.1.1/",
-          "react/": "https://esm.sh/react@^19.1.1/",
-          "react": "https://esm.sh/react@^19.1.1"
-        }
-      }
-    </script>
     <style>
       .preserve-3d {
         transform-style: preserve-3d;

--- a/mutation-brawler/package.json
+++ b/mutation-brawler/package.json
@@ -9,12 +9,15 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "react-dom": "^19.1.1",
-    "react": "^19.1.1"
+    "react-dom": "19.1.1",
+    "react": "19.1.1"
   },
   "devDependencies": {
-    "@types/node": "^22.14.0",
-    "typescript": "~5.8.2",
-    "vite": "^6.2.0"
+    "@types/node": "22.14.0",
+    "typescript": "5.8.2",
+    "vite": "6.2.0",
+    "tailwindcss": "3.4.3",
+    "postcss": "8.4.47",
+    "autoprefixer": "10.4.16"
   }
 }

--- a/mutation-brawler/postcss.config.js
+++ b/mutation-brawler/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/mutation-brawler/tailwind.config.js
+++ b/mutation-brawler/tailwind.config.js
@@ -1,0 +1,9 @@
+import { type Config } from 'tailwindcss';
+
+export default {
+  content: ['./index.html', './**/*.{ts,tsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+} satisfies Config;


### PR DESCRIPTION
## Summary
- bundle React and Tailwind with Vite instead of CDN
- pin dependency versions to exact numbers
- document how to update frontend dependencies

## Testing
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/autoprefixer)*
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Cannot find module 'tailwindcss')*

------
https://chatgpt.com/codex/tasks/task_e_68a064b686a483258fc76fe696e2a191