### PR TITLE
chore: specify Node engine and update Vite scripts

### DIFF
--- a/mutation-brawler/package.json
+++ b/mutation-brawler/package.json
@@ -3,10 +3,13 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  "engines": {
+    "node": ">=20.0.0"
+  },
   "scripts": {
-    "dev": "vite",
+    "dev": "vite --host --port 5173",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview --host --port 4173"
   },
   "dependencies": {
     "react-dom": "19.1.1",


### PR DESCRIPTION
## Summary
- require Node.js v20+ in package.json
- update Vite dev and preview scripts with host and port defaults

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a06a5a7afc8325b49c5b019eea0a7e