### PR TITLE
Add 404 fallback to GitHub Pages workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -28,6 +28,7 @@ jobs:
           cache-dependency-path: mutation-brawler/package-lock.json
       - run: npm ci
       - run: npm run build
+      - run: cp dist/index.html dist/404.html
       - uses: actions/configure-pages@v5
       - uses: actions/upload-pages-artifact@v3
         with:


### PR DESCRIPTION
## Summary
- add step to copy build output to `404.html` so GitHub Pages serves a fallback page

## Testing
- `npm test` (fails: Missing script: "test")

------
https://chatgpt.com/codex/tasks/task_e_68a075e015048325aca3170b40edd230